### PR TITLE
fix: Change SelectContent to SelectItem

### DIFF
--- a/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.m
+++ b/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.m
@@ -270,7 +270,7 @@ const NSInteger FIR_MAX_CHARACTERS_IDENTITY_ATTR_VALUE_INDEX = 35;
             }
         }
         case MPCommerceEventActionClick:
-            return kFIREventSelectContent;
+            return kFIREventSelectItem;
         case MPCommerceEventActionViewDetail:
             return kFIREventViewItem;
         case MPCommerceEventActionPurchase:


### PR DESCRIPTION
Per Google's [GA4 migration docs](https://support.google.com/analytics/answer/10119380?hl=en#) - `select_content` has been changed to `select_item`.