### PR TITLE
fix: Always Capture App Instance Id

### DIFF
--- a/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.m
+++ b/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.m
@@ -70,8 +70,9 @@ const NSInteger FIR_MAX_CHARACTERS_IDENTITY_ATTR_VALUE_INDEX = 35;
     } else {
         if ([self.configuration[kMPFIRGA4ForwardRequestsServerSide] isEqualToString: @"True"]) {
             forwardRequestsServerSide = true;
-            [self updateInstanceIDIntegration];
         }
+        
+        [self updateInstanceIDIntegration];
         
         _started = YES;
         


### PR DESCRIPTION
## Summary
 - Update the kit to always gather profile information no matter if we are forwarding server side or not

 ## Testing Plan
 - Tested locally in sample app

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5076
