### PR TITLE
feat: Update Firebase GA4 to latest (10.6 to next major)

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" ~> 9.0
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" ~> 10.6
 github "mparticle/mparticle-apple-sdk" ~> 8.0
 

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
                .upToNextMajor(from: "8.0.0")),
       .package(name: "Firebase",
                url: "https://github.com/firebase/firebase-ios-sdk.git",
-               .upToNextMajor(from: "9.0.0")),
+               .upToNextMajor(from: "10.6.0")),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
               .product(name: "FirebaseAnalytics", package: "Firebase"),
             ],
             path: "mParticle-Google-Analytics-Firebase-GA4",
-            exclude: ["Info.plist"],
+            exclude: ["Info.plist", "dummy.swift"],
             publicHeadersPath: "."),
     ]
 )

--- a/mParticle-Google-Analytics-Firebase-GA4.podspec
+++ b/mParticle-Google-Analytics-Firebase-GA4.podspec
@@ -19,6 +19,6 @@ Pod::Spec.new do |s|
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
     s.ios.frameworks = 'CoreTelephony', 'SystemConfiguration'
     s.libraries = 'z'
-    s.ios.dependency 'Firebase/Core', '~> 9.0'
+    s.ios.dependency 'Firebase/Core', '~> 10.6'
 
 end


### PR DESCRIPTION
 ## Summary
Update Firebase SDK to version 10.6 up to next major version.

 ## Testing Plan
- Tested locally using CocoaPods, SPM, and Carthage
- Confirmed no breaking API changes in new version

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5136
