### PR TITLE
feat: Add NoLocation target to SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,9 @@ let package = Package(
         .library(
             name: "mParticle-Google-Analytics-Firebase-GA4",
             targets: ["mParticle-Google-Analytics-Firebase-GA4"]),
+        .library(
+            name: "mParticle-Google-Analytics-Firebase-GA4-NoLocation",
+            targets: ["mParticle-Google-Analytics-Firebase-GA4-NoLocation"])
     ],
     dependencies: [
       .package(name: "mParticle-Apple-SDK",
@@ -23,10 +26,19 @@ let package = Package(
         .target(
             name: "mParticle-Google-Analytics-Firebase-GA4",
             dependencies: [
-              .byName(name: "mParticle-Apple-SDK"),
+              .product(name: "mParticle-Apple-SDK", package: "mParticle-Apple-SDK"),
               .product(name: "FirebaseAnalytics", package: "Firebase"),
             ],
             path: "mParticle-Google-Analytics-Firebase-GA4",
+            exclude: ["Info.plist", "dummy.swift"],
+            publicHeadersPath: "."),
+        .target(
+            name: "mParticle-Google-Analytics-Firebase-GA4-NoLocation",
+            dependencies: [
+              .product(name: "mParticle-Apple-SDK-NoLocation", package: "mParticle-Apple-SDK"),
+              .product(name: "FirebaseAnalytics", package: "Firebase"),
+            ],
+            path: "SPM/mParticle-Google-Analytics-Firebase-GA4-NoLocation",
             exclude: ["Info.plist", "dummy.swift"],
             publicHeadersPath: "."),
     ]

--- a/SPM/mParticle-Google-Analytics-Firebase-GA4-NoLocation
+++ b/SPM/mParticle-Google-Analytics-Firebase-GA4-NoLocation
@@ -1,0 +1,1 @@
+../mParticle-Google-Analytics-Firebase-GA4

--- a/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.h
+++ b/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.h
@@ -1,8 +1,10 @@
 #import <Foundation/Foundation.h>
 #if defined(__has_include) && __has_include(<mParticle_Apple_SDK/mParticle.h>)
-#import <mParticle_Apple_SDK/mParticle.h>
+    #import <mParticle_Apple_SDK/mParticle.h>
+#elif defined(__has_include) && __has_include(<mParticle_Apple_SDK_NoLocation/mParticle.h>)
+    #import <mParticle_Apple_SDK_NoLocation/mParticle.h>
 #else
-#import "mParticle.h"
+    #import "mParticle.h"
 #endif
 
 @interface MPKitFirebaseGA4Analytics : NSObject <MPKitProtocol>


### PR DESCRIPTION
 ## Summary
Add dedicated NoLocation target to SPM with a dependency on the NoLocation version of the mParticle SDK. This prevents the issue where a customer adds the NoLocation SDK and then the kit depends on the standard version, which causes both to be included.

 ## Testing Plan
- Confirmed in a test app that both targets work as expected

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5439
