### PR TITLE
feat: Add Customer Configurable Standardization

### DIFF
--- a/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.h
+++ b/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.h
@@ -14,6 +14,9 @@
 @property (nonatomic, unsafe_unretained, readonly) BOOL started;
 @property (nonatomic, strong, nullable) MPKitAPI *kitApi;
 
++ (void)setCustomNameStandardization:(NSString*_Nonnull(^_Nullable)(NSString* _Nonnull name))standardization;
++ (NSString*_Nonnull(^_Nullable)(NSString* _Nonnull name))customNameStandardization;
+
 @end
 
 static NSString * _Nonnull const kMPFIRGA4ExternalUserIdentityType = @"externalUserIdentityType";

--- a/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.h
+++ b/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.h
@@ -14,8 +14,8 @@
 @property (nonatomic, unsafe_unretained, readonly) BOOL started;
 @property (nonatomic, strong, nullable) MPKitAPI *kitApi;
 
-+ (void)setCustomNameStandardization:(NSString*_Nonnull(^_Nullable)(NSString* _Nonnull name))standardization;
-+ (NSString*_Nonnull(^_Nullable)(NSString* _Nonnull name))customNameStandardization;
++ (void)setCustomNameStandardization:(NSString * _Nonnull (^_Nullable)(NSString * _Nonnull name))standardization;
++ (NSString * _Nonnull (^_Nullable)(NSString * _Nonnull name))customNameStandardization;
 
 @end
 

--- a/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.m
+++ b/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.m
@@ -11,6 +11,8 @@
     #endif
 #endif
 
+__weak static NSString* (^customNameStandardization)(NSString* name) = nil;
+
 @interface MPKitFirebaseGA4Analytics () <MPKitProtocol> {
     BOOL forwardRequestsServerSide;
 }
@@ -58,6 +60,13 @@ const NSInteger FIR_MAX_ITEM_PARAMETERS = 10;
     [MParticle registerExtension:kitRegister];
 }
 
++ (void)setCustomNameStandardization:(NSString*_Nonnull(^_Nullable)(NSString* _Nonnull name))standardization {
+    customNameStandardization = standardization;
+}
+
++ (NSString*_Nonnull(^_Nullable)(NSString* _Nonnull name))customNameStandardization {
+    return customNameStandardization;
+}
 
 - (MPKitExecStatus *)execStatus:(MPKitReturnCode)returnCode {
     return [[MPKitExecStatus alloc] initWithSDKCode:self.class.kitCode returnCode:returnCode];
@@ -171,9 +180,14 @@ const NSInteger FIR_MAX_ITEM_PARAMETERS = 10;
 }
 
 - (NSString *)standardizeNameOrKey:(NSString *)nameOrKey forEvent:(BOOL)forEvent {
+    NSString *initialValue = [nameOrKey copy];
+    if ([MPKitFirebaseGA4Analytics customNameStandardization]) {
+        initialValue = [MPKitFirebaseGA4Analytics customNameStandardization](initialValue);
+    }
+    
     NSMutableCharacterSet *firebaseAllowedCharacterSet = [NSMutableCharacterSet characterSetWithCharactersInString:firebaseAllowedCharacters];
     NSCharacterSet *notAllowedChars = [firebaseAllowedCharacterSet invertedSet];
-    NSString* truncatedString = nameOrKey;
+    NSString* truncatedString = initialValue;
     NSCharacterSet *aTozCharacterSet = [NSCharacterSet characterSetWithCharactersInString:aToZCharacters];
 
     // Remove any non-alphabetic characters from the beginning of the string

--- a/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.m
+++ b/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.m
@@ -60,11 +60,11 @@ const NSInteger FIR_MAX_ITEM_PARAMETERS = 10;
     [MParticle registerExtension:kitRegister];
 }
 
-+ (void)setCustomNameStandardization:(NSString*_Nonnull(^_Nullable)(NSString* _Nonnull name))standardization {
++ (void)setCustomNameStandardization:(NSString * _Nonnull (^_Nullable)(NSString * _Nonnull name))standardization {
     customNameStandardization = standardization;
 }
 
-+ (NSString*_Nonnull(^_Nullable)(NSString* _Nonnull name))customNameStandardization {
++ (NSString * _Nonnull (^_Nullable)(NSString * _Nonnull name))customNameStandardization {
     return customNameStandardization;
 }
 

--- a/mParticle-Google-Analytics-Firebase-GA4Tests/MPKitFirebaseGA4AnalyticsTests.m
+++ b/mParticle-Google-Analytics-Firebase-GA4Tests/MPKitFirebaseGA4AnalyticsTests.m
@@ -27,6 +27,7 @@
 }
 
 - (void)tearDown {
+    [MPKitFirebaseGA4Analytics setCustomNameStandardization:nil];
     [FIRApp resetApps];
 }
 
@@ -154,6 +155,25 @@
                               @""];
     for (NSString *emptyString in emptyStrings) {
         XCTAssertEqualObjects([exampleKit standardizeNameOrKey:emptyString forEvent:YES], @"invalid_ga4_key");
+    }
+}
+
+- (void)testSanitizationCustom {
+    MPKitFirebaseGA4Analytics *exampleKit = [[MPKitFirebaseGA4Analytics alloc] init];
+    
+    NSArray *customTest = @[@"firebase_event_name",
+                             @"google_event_name",
+                             @"ga_event_name"];
+    
+    [MPKitFirebaseGA4Analytics setCustomNameStandardization:^(NSString* name) {
+        return @"test";
+    }];
+    for (NSString *tests in customTest) {
+        XCTAssertEqualObjects([exampleKit standardizeNameOrKey:tests forEvent:YES], @"test");
+    }
+    
+    for (NSString *tests in customTest) {
+        XCTAssertEqualObjects([exampleKit standardizeNameOrKey:tests forEvent:NO], @"test");
     }
 }
 


### PR DESCRIPTION
## Summary
Implement the following scheme to support customer-configurable cleansing:

- provide a client-side callback method on the ga4 kit for event & parameters names

- callback is executed prior to our standard data cleansing

- customer receives a single event/parameter name string on each callback that can be altered as required

- our standard data cleansing method executes directly after the customer callback and cleanses anything that was missed.

 ## Testing Plan
 -Tested locally and through Unit Tests

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5465
