### PR TITLE
feat: Add product brand to ecommerce event products

### DIFF
--- a/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.m
+++ b/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.m
@@ -529,6 +529,9 @@ const NSInteger FIR_MAX_ITEM_PARAMETERS = 25;
             if (product.category) {
                 [productParameters setObject:product.category forKey:kFIRParameterItemCategory];
             }
+            if (product.brand) {
+                [productParameters setObject:product.brand forKey:kFIRParameterItemBrand];
+            }
             if (product.price) {
                 [productParameters setObject:product.price forKey:kFIRParameterPrice];
             }
@@ -564,6 +567,9 @@ const NSInteger FIR_MAX_ITEM_PARAMETERS = 25;
         }
         if (product.category) {
             [productParameters setObject:product.category forKey:kFIRParameterItemCategory];
+        }
+        if (product.brand) {
+            [productParameters setObject:product.brand forKey:kFIRParameterItemBrand];
         }
         if (product.price) {
             [productParameters setObject:product.price forKey:kFIRParameterPrice];


### PR DESCRIPTION
 ## Summary
We are adding the product brand to the ecommerce event logging to match the feature that web already has.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
Manually tested via the Firebase debugger.
Before change:
Purchase
<img width="703" alt="image" src="https://github.com/mparticle-integrations/mparticle-apple-integration-google-analytics-firebase-ga4/assets/136605018/35dd7d9c-cb3f-4ffd-bf45-a040f6c58a00">

Impression
<img width="713" alt="image" src="https://github.com/mparticle-integrations/mparticle-apple-integration-google-analytics-firebase-ga4/assets/136605018/353491f3-bbc3-4ade-97f4-ecf3ca1b3944">


After change:

Purchase
<img width="717" alt="image" src="https://github.com/mparticle-integrations/mparticle-apple-integration-google-analytics-firebase-ga4/assets/136605018/2132b19a-3784-4c4a-ac98-d168eff62aaa">

Impression
<img width="702" alt="image" src="https://github.com/mparticle-integrations/mparticle-apple-integration-google-analytics-firebase-ga4/assets/136605018/0536f1c8-f7cd-4dd5-bbe8-df6052a249f5">
