### PR TITLE
feat: forward screen custom attributes

### DIFF
--- a/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.m
+++ b/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.m
@@ -175,8 +175,8 @@ const NSInteger FIR_MAX_ITEM_PARAMETERS = 25;
         return [self execStatus:MPKitReturnCodeFail];
     }
 
-    NSString *standardizedFirebaseEventName = [self standardizeNameOrKey:event.name forEvent:YES];
-    [FIRAnalytics logEventWithName:kFIREventScreenView parameters:@{kFIRParameterScreenName: standardizedFirebaseEventName}];
+    NSMutableDictionary *screenParameters = [self getParametersForScreen:event];
+    [FIRAnalytics logEventWithName:kFIREventScreenView parameters:screenParameters];
     
     return [self execStatus:MPKitReturnCodeSuccess];
 }
@@ -260,7 +260,7 @@ const NSInteger FIR_MAX_ITEM_PARAMETERS = 25;
     return finalValue;
 }
 
-- (NSDictionary<NSString *, id> *)standardizeValues:(NSDictionary<NSString *, id> *)values forEvent:(BOOL)forEvent {
+- (NSMutableDictionary<NSString *, id> *)standardizeValues:(NSDictionary<NSString *, id> *)values forEvent:(BOOL)forEvent {
     NSMutableDictionary<NSString *, id>  *standardizedValue = [[NSMutableDictionary alloc] init];
     
     for (NSString *key in values.allKeys) {
@@ -270,6 +270,13 @@ const NSInteger FIR_MAX_ITEM_PARAMETERS = 25;
     
     [self limitDictionary:standardizedValue maxCount:FIR_MAX_EVENT_PARAMETERS_PROPERTIES];
     return standardizedValue;
+}
+
+- (NSMutableDictionary<NSString *, id> *)getParametersForScreen:(MPEvent *)screenEvent {
+    NSMutableDictionary *standardizedScreenParameters = [self standardizeValues:screenEvent.customAttributes forEvent:YES];
+    NSString *standardizedFirebaseEventName = [self standardizeNameOrKey:screenEvent.name forEvent:YES];
+    standardizedScreenParameters[kFIRParameterScreenName] = standardizedFirebaseEventName;
+    return standardizedScreenParameters;
 }
 
 - (MPKitExecStatus *)onLoginComplete:(FilteredMParticleUser *)user request:(FilteredMPIdentityApiRequest *)request {

--- a/mParticle-Google-Analytics-Firebase-GA4Tests/MPKitFirebaseGA4AnalyticsTests.m
+++ b/mParticle-Google-Analytics-Firebase-GA4Tests/MPKitFirebaseGA4AnalyticsTests.m
@@ -12,6 +12,7 @@
 - (NSString *)standardizeValue:(id)value forEvent:(BOOL)forEvent;
 - (NSString *)getEventNameForCommerceEvent:(MPCommerceEvent *)commerceEvent parameters:(NSDictionary<NSString *, id> *)parameters;
 - (NSDictionary<NSString *, id> *)getParameterForCommerceEvent:(MPCommerceEvent *)commerceEvent;
+- (NSMutableDictionary<NSString *, id> *)getParametersForScreen:(MPEvent *)screenEvent;
 @end
 
 @interface mParticle_Firebase_AnalyticsTests : XCTestCase
@@ -311,6 +312,30 @@
     [event addCustomFlags:@[kFIREventAddShippingInfo, kFIREventAddPaymentInfo] withKey:kMPFIRGA4CommerceEventType];
     eventName = [exampleKit getEventNameForCommerceEvent:event parameters:parameters];
     XCTAssertEqualObjects(kFIREventAddShippingInfo, eventName);
+}
+
+- (void)testScreenNameAttributes {
+    MPKitFirebaseGA4Analytics *exampleKit = [[MPKitFirebaseGA4Analytics alloc] init];
+    [exampleKit didFinishLaunchingWithConfiguration:@{}];
+    
+    MPEvent *event = [[MPEvent alloc] initWithName:@"testScreenName" type:MPEventTypeOther];
+    event.customAttributes = @{@"testScreenAttribute":@"value"};
+    MPKitExecStatus *execStatus = [exampleKit logScreen:event];
+    
+    XCTAssertTrue(execStatus.success);
+    
+    NSMutableDictionary<NSString *, id> *screenParameters = [exampleKit getParametersForScreen:event];
+    
+    // Even though we only pass one custom attribute, the parameters should include the standardized screen name, so the total expected count is two
+    XCTAssertEqual(screenParameters.count, 2);
+    
+    NSString *standardizedScreenName = [exampleKit standardizeNameOrKey:event.name forEvent:YES];
+    NSString *screenNameParameter = screenParameters[kFIRParameterScreenName];
+
+    // Test screen name parameter is not Nil and exists in the screen parameters dictionary
+    XCTAssertNotNil(screenNameParameter);
+    // Test screen name parameter value is correct
+    XCTAssertEqualObjects(screenNameParameter, standardizedScreenName);
 }
 
 @end


### PR DESCRIPTION
 ## Summary
 - Since we're using logEvent for screen views, we can now send the screen view event's custom attributes as part of the Params

 ## Testing Plan
 - [Y] Was this tested locally? If not, explain why.
 - Testing was done for both E2E and unit testing

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-6969
