### PR TITLE
feat: forward product custom attributes

### DIFF
--- a/mParticle-Google-Analytics-Firebase-GA4Tests/MPKitFirebaseGA4AnalyticsTests.m
+++ b/mParticle-Google-Analytics-Firebase-GA4Tests/MPKitFirebaseGA4AnalyticsTests.m
@@ -12,6 +12,7 @@
 - (NSString *)standardizeValue:(id)value forEvent:(BOOL)forEvent;
 - (NSString *)getEventNameForCommerceEvent:(MPCommerceEvent *)commerceEvent parameters:(NSDictionary<NSString *, id> *)parameters;
 - (NSDictionary<NSString *, id> *)getParameterForCommerceEvent:(MPCommerceEvent *)commerceEvent;
+- (NSMutableArray *)getParametersForProducts:(id)products;
 @end
 
 @interface mParticle_Firebase_AnalyticsTests : XCTestCase
@@ -287,6 +288,26 @@
 
     execStatus = [exampleKit logBaseEvent:purchaseEvent];
     XCTAssertTrue(execStatus.success);
+}
+
+- (void)testProductParameters {
+    MPKitFirebaseGA4Analytics *exampleKit = [[MPKitFirebaseGA4Analytics alloc] init];
+    [exampleKit didFinishLaunchingWithConfiguration:@{}];
+    
+    MPProduct *product = [[MPProduct alloc] initWithName:@"expensivePotato" sku:@"SKU123" quantity:@1 price:@40.0];
+    NSMutableDictionary<NSString *, id> *testProductCustomAttributes = [[@{@"productCustomAttribute": @"potato", @"store": @"Target"} mutableCopy] mutableCopy];
+    product.brand = @"LV";
+    product.category = @"vegetable";
+    product.userDefinedAttributes = testProductCustomAttributes;
+    
+    MPCommerceEvent *event = [[MPCommerceEvent alloc] initWithImpressionName:@"suggested products list" product:product];
+    NSSet<MPProduct *> *impressionProducts = event.impressions[@"suggested products list"];
+    
+    NSArray *itemsArray = [exampleKit getParametersForProducts:impressionProducts];
+    id item = itemsArray[0];
+    
+    // The item inside itemsArray should include 8 parameters in total including the 2 product custom attributes
+    XCTAssertEqual([item count], 8);
 }
 
 - (void)testCommerceEventCheckoutOptions {


### PR DESCRIPTION
 ## Summary
 - A customer raised an issue that we don't forward product custom attributes to GA4/Firebase, after further investigation, I was able to verify that Google accept mapped custom attributes as mentioned [here](https://firebase.google.com/docs/analytics/measure-ecommerce#objective-c_13)

 ## Testing Plan
 - [Y] Was this tested locally? If not, explain why.
 - Unit tested and E2E tested (it takes 24 hours for results to show in Firebase for this case, breakpoints were showing to be forwarded as expected and will double verify tomorrow in GA4 dashboard)

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-7038
