### PR TITLE
feat: Map product position to Firebase item index

### DIFF
--- a/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.m
+++ b/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.m
@@ -536,6 +536,10 @@ const NSInteger FIR_MAX_ITEM_PARAMETERS = 25;
         if (product.price) {
             [productParameters setObject:product.price forKey:kFIRParameterPrice];
         }
+        if (product.position) {
+            id indexParameter = @(product.position);
+            [productParameters setObject:indexParameter forKey:kFIRParameterIndex];
+        }
         if (product.userDefinedAttributes) {
             for (NSString *productCustomAttribute in product.userDefinedAttributes) {
                 [productParameters setObject:product.userDefinedAttributes[productCustomAttribute] forKey:productCustomAttribute];

--- a/mParticle-Google-Analytics-Firebase-GA4Tests/MPKitFirebaseGA4AnalyticsTests.m
+++ b/mParticle-Google-Analytics-Firebase-GA4Tests/MPKitFirebaseGA4AnalyticsTests.m
@@ -13,6 +13,7 @@
 - (NSString *)getEventNameForCommerceEvent:(MPCommerceEvent *)commerceEvent parameters:(NSDictionary<NSString *, id> *)parameters;
 - (NSDictionary<NSString *, id> *)getParameterForCommerceEvent:(MPCommerceEvent *)commerceEvent;
 - (NSMutableDictionary<NSString *, id> *)getParametersForScreen:(MPEvent *)screenEvent;
+- (NSMutableArray *)getParametersForProducts:(id)products;
 @end
 
 @interface mParticle_Firebase_AnalyticsTests : XCTestCase
@@ -298,6 +299,7 @@
     NSMutableDictionary<NSString *, id> *testProductCustomAttributes = [[@{@"productCustomAttribute": @"potato", @"store": @"Target"} mutableCopy] mutableCopy];
     product.brand = @"LV";
     product.category = @"vegetable";
+    product.position = 4;
     product.userDefinedAttributes = testProductCustomAttributes;
     
     MPCommerceEvent *event = [[MPCommerceEvent alloc] initWithImpressionName:@"suggested products list" product:product];
@@ -306,8 +308,8 @@
     NSArray *itemsArray = [exampleKit getParametersForProducts:impressionProducts];
     id item = itemsArray[0];
     
-    // The item inside itemsArray should include 8 parameters in total including the 2 product custom attributes
-    XCTAssertEqual([item count], 8);
+    // The item inside itemsArray should include 9 parameters in total including the 2 product custom attributes
+    XCTAssertEqual([item count], 9);
 }
 
 - (void)testCommerceEventCheckoutOptions {


### PR DESCRIPTION
 ## Summary
 - Firebase/GA4 have item index as part of the item parameters for eCommerce events (docs [here](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtag#view_item_list_item)) and a customer requested our kits to support this parameter since we already have product positions that can be mapped to

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - E2E and unit tested

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7176
