### PR TITLE
feat: iOS Kit Google Analytics 4 Update to 12.0.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" ~> 11.8
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" ~> 12.0
 binary "https://raw.githubusercontent.com/mParticle/mparticle-apple-sdk/main/mParticle_Apple_SDK.json" ~> 8.0
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "mParticle-Google-Analytics-Firebase-GA4",
-    platforms: [ .iOS(.v13), .tvOS(.v13) ],
+    platforms: [ .iOS(.v15), .tvOS(.v15) ],
     products: [
         .library(
             name: "mParticle-Google-Analytics-Firebase-GA4",
@@ -20,7 +20,7 @@ let package = Package(
                .upToNextMajor(from: "8.22.0")),
       .package(name: "Firebase",
                url: "https://github.com/firebase/firebase-ios-sdk.git",
-               .upToNextMajor(from: "11.8.0")),
+               .upToNextMajor(from: "12.0.0")),
     ],
     targets: [
         .target(

--- a/mParticle-Google-Analytics-Firebase-GA4.podspec
+++ b/mParticle-Google-Analytics-Firebase-GA4.podspec
@@ -14,20 +14,20 @@ Pod::Spec.new do |s|
     s.social_media_url = "https://twitter.com/mparticle"
     s.static_framework = true
 
-    s.ios.deployment_target = "13.0"
+    s.ios.deployment_target = "15.0"
     s.ios.source_files      = 'mParticle-Google-Analytics-Firebase-GA4/*.{h,m,mm}'
     s.ios.resource_bundles  = { 'mParticle-Google-Analytics-Firebase-GA4-Privacy' => ['mParticle-Google-Analytics-Firebase-GA4/PrivacyInfo.xcprivacy'] }
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.22'
     s.ios.frameworks = 'CoreTelephony', 'SystemConfiguration'
     s.libraries = 'z'
-    s.ios.dependency 'Firebase/Core', '~> 11.8'
+    s.ios.dependency 'Firebase/Core', '~> 12.0'
 
-    s.tvos.deployment_target = "13.0"
+    s.tvos.deployment_target = "15.0"
     s.tvos.source_files      = 'mParticle-Google-Analytics-Firebase-GA4/*.{h,m,mm}'
     s.ios.resource_bundles  = { 'mParticle-Google-Analytics-Firebase-GA4-Privacy' => ['mParticle-Google-Analytics-Firebase-GA4/PrivacyInfo.xcprivacy'] }
     s.tvos.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.22'
     s.tvos.frameworks = 'SystemConfiguration'
     s.libraries = 'z'
-    s.tvos.dependency 'Firebase/Core', '~> 11.8'
+    s.tvos.dependency 'Firebase/Core', '~> 12.0'
 
 end


### PR DESCRIPTION
 ## Summary
 - This PR is to update the Firebase version to [v12](https://firebase.google.com/support/release-notes/ios#version_1200_-_july_15_2025).

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Verified locally via E2E testing to confirm data flows correctly.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7503
