### PR TITLE
Fix product.position condition to handle zero values

### DIFF
--- a/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.m
+++ b/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.m
@@ -536,7 +536,7 @@ const NSInteger FIR_MAX_ITEM_PARAMETERS = 25;
         if (product.price) {
             [productParameters setObject:product.price forKey:kFIRParameterPrice];
         }
-        if (product.position != nil && [product.position isKindOfClass:[NSNumber class]]) {
+        if (product.position >= 0) {
             id indexParameter = @(product.position);
             [productParameters setObject:indexParameter forKey:kFIRParameterIndex];
         }

--- a/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.m
+++ b/mParticle-Google-Analytics-Firebase-GA4/MPKitFirebaseGA4Analytics.m
@@ -536,7 +536,7 @@ const NSInteger FIR_MAX_ITEM_PARAMETERS = 25;
         if (product.price) {
             [productParameters setObject:product.price forKey:kFIRParameterPrice];
         }
-        if (product.position) {
+        if (product.position != nil && [product.position isKindOfClass:[NSNumber class]]) {
             id indexParameter = @(product.position);
             [productParameters setObject:indexParameter forKey:kFIRParameterIndex];
         }

--- a/mParticle-Google-Analytics-Firebase-GA4Tests/MPKitFirebaseGA4AnalyticsTests.m
+++ b/mParticle-Google-Analytics-Firebase-GA4Tests/MPKitFirebaseGA4AnalyticsTests.m
@@ -312,6 +312,27 @@
     XCTAssertEqual([item count], 9);
 }
 
+- (void)testProductPositionEqualZero {
+    MPKitFirebaseGA4Analytics *exampleKit = [[MPKitFirebaseGA4Analytics alloc] init];
+    [exampleKit didFinishLaunchingWithConfiguration:@{}];
+    
+    MPProduct *product = [[MPProduct alloc] initWithName:@"expensivePotato" sku:@"SKU123" quantity:@1 price:@40.0];
+    NSMutableDictionary<NSString *, id> *testProductCustomAttributes = [[@{@"productCustomAttribute": @"potato", @"store": @"Target"} mutableCopy] mutableCopy];
+    product.brand = @"LV";
+    product.category = @"vegetable";
+    product.position = 0;
+    product.userDefinedAttributes = testProductCustomAttributes;
+    
+    MPCommerceEvent *event = [[MPCommerceEvent alloc] initWithImpressionName:@"suggested products list" product:product];
+    NSSet<MPProduct *> *impressionProducts = event.impressions[@"suggested products list"];
+    
+    NSArray *itemsArray = [exampleKit getParametersForProducts:impressionProducts];
+    id item = itemsArray[0];
+    
+    // The item inside itemsArray should include 9 parameters in total including the 2 product custom attributes
+    XCTAssertEqual([item count], 9);
+}
+
 - (void)testCommerceEventCheckoutOptions {
     MPKitFirebaseGA4Analytics *exampleKit = [[MPKitFirebaseGA4Analytics alloc] init];
     [exampleKit didFinishLaunchingWithConfiguration:@{}];


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
The fix ensures that when product.position = 0 is set, it will be properly included in Firebase GA4 parameters instead of being skipped.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 I tested it with my own app, adding the dependency via podfile from my github repo

 
<img width="815" height="216" alt="Screenshot 2025-08-04 at 4 21 04 PM" src="https://github.com/user-attachments/assets/7a05213c-0704-414d-9a19-f7f349e26f05" />


 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes NONE
